### PR TITLE
Enable strict typescript

### DIFF
--- a/ui-build.sbt
+++ b/ui-build.sbt
@@ -21,12 +21,9 @@ val isWindows = System.getProperty("os.name").toLowerCase().contains("win")
 def runOnCommandline(script: String)(implicit dir: File): Int = {
   if(isWindows){ Process("cmd /c " + script, dir) } else { Process(script, dir) } }!
 
-// Check of node_modules directory exist in given directory.
-def isNodeModulesInstalled(implicit dir: File): Boolean = (dir / "node_modules").exists()
-
 // Execute `npm install` command to install all node module dependencies. Return Success if already installed.
 def runNpmInstall(implicit dir: File): Int =
-  if (isNodeModulesInstalled) Success else runOnCommandline(FrontendCommands.dependencyInstall)
+  runOnCommandline(FrontendCommands.dependencyInstall)
 
 // Execute task if node modules are installed, else return Error status.
 def ifNodeModulesInstalled(task: => Int)(implicit dir: File): Int =

--- a/ui/src/app/app.component.ts
+++ b/ui/src/app/app.component.ts
@@ -8,8 +8,8 @@ import { AppService } from './app.service';
   styleUrls: ['./app.component.css']
 })
 export class AppComponent {
-  title: string;
-  postRequestResponse: string;
+  title: string | undefined;
+  postRequestResponse: string | undefined;
 
   constructor(private appService: AppService) {
     this.appService.getWelcomeMessage().subscribe((data: any) => {

--- a/ui/src/app/http-interceptor.service.ts
+++ b/ui/src/app/http-interceptor.service.ts
@@ -43,7 +43,7 @@ export class AppHttpInterceptorService implements HttpInterceptor {
     }
   }
 
-  private handleClientSideError(status: number): string {
+  private handleClientSideError(status: number): string | undefined {
     switch (status) {
       case 0:
         return 'NO INTERNET CONNECTION';

--- a/ui/tsconfig.json
+++ b/ui/tsconfig.json
@@ -19,6 +19,7 @@
       "es2018",
       "dom"
     ],
-    "incremental": true
+    "incremental": true,
+    "strict": true
   }
 }


### PR DESCRIPTION
Thank you very much for this awesome seed, we are using it quite heavily.

There are two things we always change in our projects:

Enabling strict typescript. We think this is the best pratice and doing
that from early on makes everything simpler in the long run.

Removing the "do not install node-modules if the directory already
exists" (see thee change in ui-build.sbt). With our CI setup this would
always mean that Jenkins would not update node modules if there was a
previous run which used the same workspace and already installed
modules.